### PR TITLE
Moved babel packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,6 @@
     ]
   },
   "dependencies": {
-    "babel-cli": "^6.10.1",
-    "babel-core": "^6.10.4",
-    "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "babel-runtime": "^6.22.0",
     "date-format-lite": "^0.9.1",
     "get-csv": "^2.1.3",
     "isomorphic-fetch": "^2.2.1",
@@ -49,6 +43,12 @@
     "source-map-support": "^0.4.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.10.1",
+    "babel-core": "^6.10.4",
+    "babel-polyfill": "^6.9.1",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-runtime": "^6.22.0",
     "ava": "^0.15.2",
     "ava-spec": "^1.0.1",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Installing it as normal dependencies will create conflicts when using a different Babel version in your project.